### PR TITLE
Reset pagination when filters change

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,18 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders job search heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/find a job/i);
+  expect(heading).toBeInTheDocument();
+});
+
+test('filtering resets pagination', () => {
+  render(<App />);
+  const nextBtn = screen.getByRole('button', { name: /next/i });
+  fireEvent.click(nextBtn);
+  const searchInput = screen.getByPlaceholderText(/search by job title/i);
+  fireEvent.change(searchInput, { target: { value: 'Senior Frontend Developer' } });
+  const jobTitle = screen.getByText(/senior frontend developer/i);
+  expect(jobTitle).toBeInTheDocument();
 });

--- a/src/components/Jobs.js
+++ b/src/components/Jobs.js
@@ -35,6 +35,11 @@ export default function Jobs() {
     doFilter();
   }, [searchQuery, jobType, doFilter]);
 
+  // Reset pagination when filters change to avoid empty pages
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchQuery, jobType]);
+
   const clearSearch = () => {
     setSearchQuery("");
   };


### PR DESCRIPTION
## Summary
- ensure pagination resets when search or job type filter changes to avoid empty result pages
- update tests to check for heading and verify pagination reset behavior

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_68a0de9ba9a48325842c78589f80379e